### PR TITLE
59 fix test linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ SET(CMAKE_CXX_FLAGS  "-pthread")
 
 project ("RTEP-the-raspberry-jam")
 add_subdirectory(AlsaEffects)
-#add_subdirectory(test)
+add_subdirectory(test)
 
 add_executable(rpj main.cpp)
 
@@ -18,5 +18,5 @@ if (ALSA_FOUND)
 	target_link_libraries(rpj PUBLIC ${ALSA_LIBRARIES})
 endif(ALSA_FOUND)
 
-#enable_testing()
-#add_test(NAME MyTest COMMAND Test)
+enable_testing()
+add_test(NAME MyTest COMMAND Test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,10 +1,10 @@
 find_package(Boost COMPONENTS system filesystem unit_test_framework REQUIRED)
-include_directories(${DEMO_SOURCE_DIR}/AlsaEffects/include ${Boost_INCLUDE_DIRS} )
+include_directories(${CMAKE_SOURCE_DIR}/AlsaEffects/include ${Boost_INCLUDE_DIRS} )
 add_definitions(-DBOOST_TEST_DYN_LINK)
 
 add_executable (Test test.cpp)
 target_link_libraries(Test
- include
+ AlsaEffects
  ${Boost_FILESYSTEM_LIBRARY}
  ${Boost_SYSTEM_LIBRARY}
  ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,11 +1,21 @@
 #define BOOST_TEST_MODULE AlsaBufferConverterTests
 #include <boost/test/unit_test.hpp>
 #include "AlsaBufferConverter.h"
+#include "DataFormat.h"
 
 
 BOOST_AUTO_TEST_CASE(PassTest)
 {
-    uint8_t originalData[] = { 0x7F, 0xFF, 0xFF, 0x40, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x80, 0x00, 0x00 ,
+    // Test Setup:
+    eEndianness testEndian = eBIG;
+    uint8_t testBytesPerSymbol = 3;
+    uint16_t testFramesPerBuffer = 44;
+
+    // Create objects to be used in test
+	AlsaBufferConverter* testConverter = new AlsaBufferConverter(testEndian,testBytesPerSymbol,testFramesPerBuffer);
+    ChannelSamples* testSamples = new ChannelSamples(testFramesPerBuffer);
+
+    uint8_t input[] = { 0x7F, 0xFF, 0xFF, 0x40, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x80, 0x00, 0x00 ,
                       0x7F, 0xFF, 0xFF, 0x40, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x80, 0x00, 0x00 ,
                       0x7F, 0xFF, 0xFF, 0x40, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x80, 0x00, 0x00 ,
                       0x7F, 0xFF, 0xFF, 0x40, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x80, 0x00, 0x00 ,
@@ -27,19 +37,20 @@ BOOST_AUTO_TEST_CASE(PassTest)
                       0x7F, 0xFF, 0xFF, 0x40, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x80, 0x00, 0x00 ,
                       0x7F, 0xFF, 0xFF, 0x40, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x80, 0x00, 0x00 ,
                       0x7F, 0xFF, 0xFF, 0x40, 0x00, 0x00, 0xc0, 0x00, 0x00, 0x80, 0x00, 0x00 };
-    uint8_t finalData[264];
+    uint8_t output[sizeof(input)];
 
-	AlsaBufferConverter* test = new AlsaBufferConverter;
-    ChannelSamples* initial_data = new ChannelSamples(44);
-    test->getSamples(initial_data, originalData);
-    test->getBuffer(finalData,initial_data);
+    // Perform conversion
+    testConverter->getSamples(testSamples, input);
+    testConverter->getBuffer(output, testSamples);
 
-    for (size_t i = 0; i < sizeof(originalData); ++i)
+    // Test to see if conversion was successful
+    for (size_t i = 0; i < sizeof(input); ++i)
     {
-        BOOST_CHECK_EQUAL(originalData[i],finalData.get()[i]);
+        BOOST_CHECK_EQUAL(input[i],output[i]);
     }
 
-    delete test;
-    delete initial_data;
+    // Free memory allocated for test
+    delete testConverter;
+    delete testSamples;
 }
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,4 +1,4 @@
-#define BOOST_TEST_MODULE AlsaBufferConverterTests
+#define BOOST_TEST_MODULE Test
 #include <boost/test/unit_test.hpp>
 #include "AlsaBufferConverter.h"
 #include "DataFormat.h"
@@ -43,14 +43,11 @@ BOOST_AUTO_TEST_CASE(PassTest)
     testConverter->getSamples(testSamples, input);
     testConverter->getBuffer(output, testSamples);
 
-    // Test to see if conversion was successful
-    for (size_t i = 0; i < sizeof(input); ++i)
-    {
-        BOOST_CHECK_EQUAL(input[i],output[i]);
-    }
-
     // Free memory allocated for test
     delete testConverter;
     delete testSamples;
+
+    // Test to see if conversion was successful
+    BOOST_TEST(input == output);
 }
 


### PR DESCRIPTION
Test files are now being successfully linked. Turns out there was a typo in one of the CMakeList.txt files where it was unable to correctly find the include directory. This will now close Issues #37 and #59 .